### PR TITLE
Use alias for PHPUnit_Framework_TestCase

### DIFF
--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -34,6 +34,8 @@ require_once 'Zend/Session.php';
 /** @see Zend_Registry */
 require_once 'Zend/Registry.php';
 
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
+
 /**
  * Functional testing scaffold for MVC applications
  *


### PR DESCRIPTION
PHPUnit >= 6 no longer supports `PHPUnit_Framework_TestCase` and has been replaced with `PHPUnit\Framework\TestCase`. See https://thephp.cc/news/2017/02/migrating-to-phpunit-6 for more information.