### PR TITLE
Add missing expected type

### DIFF
--- a/library/Zend/File/Transfer/Adapter/Abstract.php
+++ b/library/Zend/File/Transfer/Adapter/Abstract.php
@@ -324,7 +324,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
     /**
      * Adds a new validator for this class
      *
-     * @param  string|array $validator           Type of validator to add
+     * @param  string|array|Zend_Validate_Interface $validator           Type of validator to add
      * @param  boolean      $breakChainOnFailure If the validation chain should stop an failure
      * @param  string|array $options             Options to set for the validator
      * @param  string|array $files               Files to limit this validator to


### PR DESCRIPTION
Without this, automated code quality checks will complain when an instance of Zend_Validate_Interface is provided